### PR TITLE
Fix documentation integrity issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Kilden til Tolletatens offentlige API-sider på toll.github.io
 
 HTML-sidene med tilhørende innholdspesifikke spesifikke media-filer ligger under `/api` (og `/api/media`).
-Filen `/api/template.html` bør brukes som utgangspunkt for nye sider.
+Bruk en eksisterende side i den aktuelle delen av `/api` som utgangspunkt for nye sider.
 
 Styling ligger utrolig nok på `/style`.
 

--- a/api/document/document-api-EN.html
+++ b/api/document/document-api-EN.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>API for uploading documents</title>

--- a/api/mo/asynkrone-valideringsfeil.html
+++ b/api/mo/asynkrone-valideringsfeil.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
 <head>
     <meta charset="UTF-8">
     <title>Oversikt over valideringsfeil for API i MO</title>
@@ -418,7 +418,7 @@
                     </li>
                 </ul>
 
-                <h4 id="Rettelse.10">Rettelse</h4>
+                <h4 id="Rettelse.10b">Rettelse</h4>
 
                 <p>Verifiser og eventuelt endre slik at exportId er korrekt og har riktig
                     status i AES.<br>

--- a/api/mo/beskrivelse-av-ankomst-api-EN.html
+++ b/api/mo/beskrivelse-av-ankomst-api-EN.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>Description of Arrival API</title>

--- a/api/mo/prosedyre-mo-tog-EN.html
+++ b/api/mo/prosedyre-mo-tog-EN.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="no">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <title>API for reporting and information, rail</title>

--- a/api/mo/synkrone-valideringsfeil.html
+++ b/api/mo/synkrone-valideringsfeil.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
 <head>
     <meta charset="UTF-8">
     <title>Oversikt over valideringsfeil for API i Melding/opplysning</title>

--- a/api/mo/ufullstendig-dokumentasjon.html
+++ b/api/mo/ufullstendig-dokumentasjon.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
 <head>
     <meta charset="UTF-8">
     <title>Oversikt over valideringsfeil for API i MO</title>
@@ -115,8 +115,8 @@
                     dette feltet. Dette gjelder referanser til tidligere tollprosedyrer som
                     varene har vært underlagt. Dersom man oppgir at tidligere tollprosedyre er
                     eksport, så kan man ikke henvise til en referanse til transittering.<br>
-                    Se valg av tollprosedyre <a
-                            href="mo-vei.html#utfyllingForsend">mo-vei.html#utfyllingForsend</a></p>
+                    Se <a href="melde-og-opplysning.html#utfyllingForsend">valg av tollprosedyre i
+                        API-definisjonene</a>.</p>
                 <h4 id="Rettelse.31">Correction</h4>
                 <p>Enten endre verdien i feltet eller outgoingProcedure. Send inn på nytt.
                     Bruk ny &quot;requestId&quot; man får i retur for ny innsendelse og


### PR DESCRIPTION
## What changed

- correct the root `lang` attribute on six Norwegian and English documentation pages
- replace a link to the removed `mo-vei.html` page with the current notification and disclosure guide
- make the duplicated `Rettelse.10` fragment identifier unique and consistent with its surrounding `10b` section
- replace README guidance that referenced the deleted `api/template.html` file

## Why

The 2025 documentation revamp removed the old template and `mo-vei.html`, but two references remained. A handful of language declarations and one copied fragment identifier had also drifted from their page content. This caused one local 404, ambiguous fragment navigation, incorrect language metadata for assistive technology, and misleading contributor guidance.

## Validation

- scanned all 84 HTML pages: zero broken local targets
- verified zero broken local fragments
- verified zero duplicate IDs
- verified zero language mismatches across Norwegian/English page pairs
- ran `git diff --check`
