### PR TITLE
Add generated llms.txt documentation index

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.idea/
 *.bak
 /toll.github.io.iml
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ Filen `/api/template.html` bør brukes som utgangspunkt for nye sider.
 Styling ligger utrolig nok på `/style`.
 
 Utgangspunktet for det som vises på https://toll.github.io er i `/index.html`. 
+
+## llms.txt
+
+`/llms.txt` er en maskinlesbar oversikt over dokumentasjonen. Filen genereres fra
+HTML-sidene i repoet:
+
+```sh
+python3 scripts/generate_llms_txt.py
+```
+
+Bruk `python3 scripts/generate_llms_txt.py --check` for å kontrollere at den
+genererte filen er oppdatert uten å skrive til arbeidsområdet.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,107 @@
+# Norwegian Customs API documentation
+
+> Official Norwegian Customs documentation for public data and API services, with guides in Norwegian and English.
+
+This is a generated map of the HTML documentation. API behavior, schemas, authentication requirements, and URLs should be verified against the linked pages.
+
+## Start here
+
+- [Tolletatens data- og API-dokumentasjon](https://toll.github.io/): Norwegian.
+- [Norwegian Customs' data- and API-documentation](https://toll.github.io/index-EN.html): English.
+
+## Document upload
+
+- [API for opplasting av dokumenter](https://toll.github.io/api/document/document-api.html): Norwegian.
+- [API for uploading documents](https://toll.github.io/api/document/document-api-EN.html): English.
+
+## ICS2 consignments
+
+- [API for fremlegging og kontrolldirigering av ICS2-forsendelser](https://toll.github.io/api/ics2/ics2-forsendelser.html): Norwegian.
+- [API for presentation of goods and control direction of ICS2 consignments](https://toll.github.io/api/ics2/ics2-forsendelser-EN.html): English.
+
+## Maskinporten integration
+
+- [Bestille sertifikat – norsk virksomhet – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/bestille-sertifikat-norsk.html): Norwegian.
+- [Order a certificate – Norwegian business – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/bestille-sertifikat-norsk-EN.html): English.
+- [Bestille sertifikat – utenlandsk virksomhet – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/bestille-sertifikat-utenlandsk.html): Norwegian.
+- [Order a certificate – foreign business – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/bestille-sertifikat-utenlandsk-EN.html): English.
+- [Bestille sertifikat – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/bestille-sertifikat.html): Norwegian.
+- [Order a certificate – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/bestille-sertifikat-EN.html): English.
+- [Hva er Maskinporten? – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/hva-er-maskinporten.html): Norwegian.
+- [What is Maskinporten? – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/hva-er-maskinporten-EN.html): English.
+- [Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/index-maskinporten-integration.html): Norwegian.
+- [Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/index-maskinporten-integration-EN.html): English.
+- [Maskinporten](https://toll.github.io/api/maskinporten/maskinporten.html): Norwegian.
+- [Maskinporten](https://toll.github.io/api/maskinporten/maskinporten-EN.html): English.
+- [Onboarding – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/onboarding.html): Norwegian.
+- [Onboarding – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/onboarding-EN.html): English.
+- [Teknisk integrasjon – Integrasjonsguide Maskinporten](https://toll.github.io/api/maskinporten/teknisk-integrasjon.html): Norwegian.
+- [Technical integration – Maskinporten Integration Guide](https://toll.github.io/api/maskinporten/teknisk-integrasjon-EN.html): English.
+
+## Notification and disclosure guides
+
+- [Oversikt over valideringsfeil for API i MO](https://toll.github.io/api/mo/asynkrone-valideringsfeil.html): Norwegian.
+- [Overview of validation errors for API in MO](https://toll.github.io/api/mo/asynkrone-valideringsfeil-EN.html): English.
+- [Beskrivelse av ankomst-API i MO](https://toll.github.io/api/mo/beskrivelse-av-ankomst-api.html): Norwegian.
+- [Description of Arrival API](https://toll.github.io/api/mo/beskrivelse-av-ankomst-api-EN.html): English.
+- [Beskrivelse av koblings-API i MO](https://toll.github.io/api/mo/beskrivelse-av-koblings-api.html): Norwegian.
+- [Description of Relation API](https://toll.github.io/api/mo/beskrivelse-av-koblings-api-EN.html): English.
+- [Beskrivelse av spørre-API i MO](https://toll.github.io/api/mo/beskrivelse-av-sporre-api.html): Norwegian.
+- [Description of Query API](https://toll.github.io/api/mo/beskrivelse-av-sporre-api-EN.html): English.
+- [Fremlegging og kontrolldirigering](https://toll.github.io/api/mo/fremlegging-og-kontrolldirigering.html): Norwegian.
+- [Presentation and Control Routing](https://toll.github.io/api/mo/fremlegging-og-kontrolldirigering-EN.html): English.
+- [Funksjonell beskrivelse av tjenesten](https://toll.github.io/api/mo/funksjonell-beskrivelse-av-tjenesten.html): Norwegian.
+- [Functional Description of the Service](https://toll.github.io/api/mo/funksjonell-beskrivelse-av-tjenesten-EN.html): English.
+- [API for melde- og opplysning, sjø fra SafeSeaNet (SSNN)](https://toll.github.io/api/mo/hvordan-fylle-ut-safeSeaNet.html): Norwegian.
+- [API for Notification and Information, Maritime from SafeSeaNet (SSNN)](https://toll.github.io/api/mo/hvordan-fylle-ut-safeSeaNet-EN.html): English.
+- [Hvordan sende inn ulike deklarsjonsmeldinger](https://toll.github.io/api/mo/hvordan-sende-inn-meldinger.html): Norwegian.
+- [How to Submit Various Declaration Messages](https://toll.github.io/api/mo/hvordan-sende-inn-meldinger-EN.html): English.
+- [Informasjon og meldinger - Kystverket](https://toll.github.io/api/mo/informasjon-og-meldinger-kystverket.html): Norwegian.
+- [Information and Messages](https://toll.github.io/api/mo/informasjon-og-meldinger-kystverket-EN.html): English.
+- [Informasjon og meldinger](https://toll.github.io/api/mo/informasjon-og-meldinger.html): Norwegian.
+- [Information and Messages](https://toll.github.io/api/mo/informasjon-og-meldinger-EN.html): English.
+- [Kobling, oppdatering og sletting av meldinger](https://toll.github.io/api/mo/kobling-oppdatering-og-sletting.html): Norwegian.
+- [Linking, Updating and Deleting Messages](https://toll.github.io/api/mo/kobling-oppdatering-og-sletting-EN.html): English.
+- [Melde og opplysning](https://toll.github.io/api/mo/melde-og-opplysning.html): Norwegian.
+- [Notification and Disclosure](https://toll.github.io/api/mo/melde-og-opplysning-EN.html): English.
+- [Aktuelle eksempler - melding om forsendelse (House Consignment)](https://toll.github.io/api/mo/mo-eksempler.html): Norwegian.
+- [Examples – Notification of House Consignment](https://toll.github.io/api/mo/mo-eksempler-EN.html): English.
+- [Kodeverk i API for melde og opplysning](https://toll.github.io/api/mo/mo-kodeverk.html): Norwegian.
+- [Code lists in the API for notification and information](https://toll.github.io/api/mo/mo-kodeverk-EN.html): English.
+- [Fremlegging og kontrolldirigering – forklart med eksempler](https://toll.github.io/api/mo/mo-vei-fly-forklaring.html): Norwegian.
+- [Presentation and control routing – by example](https://toll.github.io/api/mo/mo-vei-fly-forklaring-EN.html): English.
+- [API for melde- og opplysning, fly](https://toll.github.io/api/mo/prosedyre-mo-fly.html): Norwegian.
+- [API for reporting and information, air](https://toll.github.io/api/mo/prosedyre-mo-fly-EN.html): English.
+- [API for melde og opplysning, sjø, kystverket (SSNN)](https://toll.github.io/api/mo/prosedyre-mo-sjo-kystverket.html): Norwegian.
+- [API for Notification and Information, Maritime, Norwegian Coastal Administration (SSNN)](https://toll.github.io/api/mo/prosedyre-mo-sjo-kystverket-EN.html): English.
+- [API for melde- og opplysning, sjø](https://toll.github.io/api/mo/prosedyre-mo-sjo.html): Norwegian.
+- [API for reporting and information, maritime](https://toll.github.io/api/mo/prosedyre-mo-sjo-EN.html): English.
+- [API for melde- og opplysning, tog](https://toll.github.io/api/mo/prosedyre-mo-tog.html): Norwegian.
+- [API for reporting and information, rail](https://toll.github.io/api/mo/prosedyre-mo-tog-EN.html): English.
+- [API for melde- og opplysning, kjøretøy på vei/ferge - versjon 2](https://toll.github.io/api/mo/prosedyre-mo-vei-ferge.html): Norwegian.
+- [API for reporting and information, vehicles on road/ferry - version 2](https://toll.github.io/api/mo/prosedyre-mo-vei-ferge-EN.html): English.
+- [Sentrale dataelementer og meldinger](https://toll.github.io/api/mo/sentrale-dataelementer-og-meldinger-ssnn.html): Norwegian.
+- [Central Data Elements and Messages](https://toll.github.io/api/mo/sentrale-dataelementer-og-meldinger-ssnn-EN.html): English.
+- [Informasjonsmodeller - Sentrale dataelementer og meldinger](https://toll.github.io/api/mo/sentrale-dataelementer.html): Norwegian.
+- [Information Models - Central Data Elements and Messages](https://toll.github.io/api/mo/sentrale-dataelementer-EN.html): English.
+- [Oversikt over valideringsfeil for API i Melding/opplysning](https://toll.github.io/api/mo/synkrone-valideringsfeil.html): Norwegian.
+- [Overview of Validation Errors for API in MO](https://toll.github.io/api/mo/synkrone-valideringsfeil-EN.html): English.
+- [Oversikt over valideringsfeil for API i MO](https://toll.github.io/api/mo/ufullstendig-dokumentasjon.html): Norwegian.
+- [Overview of validation errors for API in MO](https://toll.github.io/api/mo/ufullstendig-dokumentasjon-EN.html): English.
+
+## API references
+
+- [document-api](https://toll.github.io/api/document/document-api-link.html): English.
+- [Maritime SSNN api](https://toll.github.io/api/mo/maritime-ssnn-api.html): English.
+- [Maritime SSNN status api](https://toll.github.io/api/mo/maritime-ssnn-status-api.html): English.
+- [movement-air-api](https://toll.github.io/api/mo/movement-air-api.html): English.
+- [movement-air-query-api](https://toll.github.io/api/mo/movement-air-query-api.html): English.
+- [movement-arrival-api](https://toll.github.io/api/mo/movement-arrival-api.html): English.
+- [movement-maritime-api](https://toll.github.io/api/mo/movement-maritime-api.html): English.
+- [movement-maritime-query-api](https://toll.github.io/api/mo/movement-maritime-query-api.html): English.
+- [movement/presentation](https://toll.github.io/api/mo/movement-presentation-api.html): English.
+- [movement-rail-api](https://toll.github.io/api/mo/movement-rail-api.html): English.
+- [movement-rail-query-api](https://toll.github.io/api/mo/movement-rail-query-api.html): English.
+- [movement-road-api versjon 2](https://toll.github.io/api/mo/movement-road-api-v2.html): English.
+- [movement-road-query-api v.2](https://toll.github.io/api/mo/movement-road-query-api-v2.html): English.
+- [movement/routing](https://toll.github.io/api/mo/movement-routing-api.html): English.

--- a/scripts/generate_llms_txt.py
+++ b/scripts/generate_llms_txt.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Generate the site's llms.txt index from its HTML documentation."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import quote, urljoin
+
+
+DEFAULT_BASE_URL = "https://toll.github.io/"
+
+
+@dataclass(frozen=True)
+class Page:
+    path: Path
+    title: str
+    declared_language: str
+
+
+class PageMetadataParser(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.declared_language = ""
+        self._in_title = False
+        self._title_parts: list[str] = []
+
+    @property
+    def title(self) -> str:
+        return " ".join("".join(self._title_parts).split())
+
+    def handle_starttag(
+        self, tag: str, attrs: list[tuple[str, str | None]]
+    ) -> None:
+        if tag == "html":
+            self.declared_language = dict(attrs).get("lang") or ""
+        elif tag == "title":
+            self._in_title = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "title":
+            self._in_title = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_title:
+            self._title_parts.append(data)
+
+
+def read_page(path: Path, root: Path) -> Page:
+    parser = PageMetadataParser()
+    parser.feed(path.read_text(encoding="utf-8"))
+    if not parser.title:
+        raise ValueError(f"Missing <title> in {path.relative_to(root)}")
+    return Page(path.relative_to(root), parser.title, parser.declared_language)
+
+
+def language_for(page: Page, paths: set[Path]) -> str:
+    if page.path.stem.endswith("-EN"):
+        return "English"
+
+    english_sibling = page.path.with_name(f"{page.path.stem}-EN.html")
+    if page.path == Path("index.html") or english_sibling in paths:
+        return "Norwegian"
+
+    if page.declared_language.lower().startswith("en"):
+        return "English"
+    if page.declared_language.lower().startswith(("nb", "nn", "no")):
+        return "Norwegian"
+    return page.declared_language or "Language not declared"
+
+
+def section_for(path: Path) -> str:
+    if path.parent == Path("."):
+        return "Start here"
+
+    if path.name == "document-api-link.html" or path.name.startswith(
+        ("movement-", "maritime-ssnn-")
+    ):
+        return "API references"
+
+    sections = {
+        Path("api/document"): "Document upload",
+        Path("api/ics2"): "ICS2 consignments",
+        Path("api/maskinporten"): "Maskinporten integration",
+        Path("api/mo"): "Notification and disclosure guides",
+    }
+    try:
+        return sections[path.parent]
+    except KeyError as error:
+        raise ValueError(f"No llms.txt section configured for {path}") from error
+
+
+def page_url(path: Path, base_url: str) -> str:
+    if path == Path("index.html"):
+        return base_url
+    encoded_path = "/".join(quote(part) for part in path.parts)
+    return urljoin(base_url, encoded_path)
+
+
+def markdown_link_text(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("[", "\\[").replace("]", "\\]")
+
+
+def page_sort_key(page: Page, paths: set[Path]) -> tuple[str, int]:
+    paired_path = page.path.as_posix().replace("-EN.html", ".html")
+    language_order = 0 if language_for(page, paths) == "Norwegian" else 1
+    return paired_path.casefold(), language_order
+
+
+def generate(root: Path, base_url: str = DEFAULT_BASE_URL) -> str:
+    base_url = f"{base_url.rstrip('/')}/"
+    pages = [read_page(path, root) for path in sorted(root.rglob("*.html"))]
+    paths = {page.path for page in pages}
+
+    grouped: dict[str, list[Page]] = {}
+    for page in pages:
+        grouped.setdefault(section_for(page.path), []).append(page)
+
+    section_order = (
+        "Start here",
+        "Document upload",
+        "ICS2 consignments",
+        "Maskinporten integration",
+        "Notification and disclosure guides",
+        "API references",
+    )
+    lines = [
+        "# Norwegian Customs API documentation",
+        "",
+        "> Official Norwegian Customs documentation for public data and API services, with guides in Norwegian and English.",
+        "",
+        "This is a generated map of the HTML documentation. API behavior, schemas, authentication requirements, and URLs should be verified against the linked pages.",
+    ]
+
+    for section in section_order:
+        section_pages = grouped.pop(section, [])
+        if not section_pages:
+            continue
+        lines.extend(("", f"## {section}", ""))
+        for page in sorted(section_pages, key=lambda item: page_sort_key(item, paths)):
+            language = language_for(page, paths)
+            lines.append(
+                f"- [{markdown_link_text(page.title)}]({page_url(page.path, base_url)}): {language}."
+            )
+
+    if grouped:
+        raise ValueError(f"Unordered llms.txt sections: {', '.join(sorted(grouped))}")
+
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"Public site root (default: {DEFAULT_BASE_URL})",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero instead of updating an out-of-date llms.txt",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(__file__).resolve().parents[1]
+    output_path = root / "llms.txt"
+    generated = generate(root, args.base_url)
+
+    if args.check:
+        current = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+        if current != generated:
+            print("llms.txt is out of date; run scripts/generate_llms_txt.py", file=sys.stderr)
+            return 1
+        print("llms.txt is up to date")
+        return 0
+
+    output_path.write_text(generated, encoding="utf-8")
+    print(f"Wrote {output_path.relative_to(root)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_llms_txt.py
+++ b/tests/test_generate_llms_txt.py
@@ -1,0 +1,44 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "generate_llms_txt", ROOT / "scripts" / "generate_llms_txt.py"
+)
+GENERATOR = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+sys.modules[SPEC.name] = GENERATOR
+SPEC.loader.exec_module(GENERATOR)
+
+
+class GenerateLlmsTxtTest(unittest.TestCase):
+    def test_committed_file_matches_generator(self):
+        self.assertEqual(
+            (ROOT / "llms.txt").read_text(encoding="utf-8"),
+            GENERATOR.generate(ROOT),
+        )
+
+    def test_every_html_page_is_linked_once(self):
+        generated = GENERATOR.generate(ROOT)
+        for path in ROOT.rglob("*.html"):
+            url = GENERATOR.page_url(path.relative_to(ROOT), GENERATOR.DEFAULT_BASE_URL)
+            self.assertEqual(generated.count(f"]({url})"), 1, path)
+
+    def test_parser_normalizes_title_text_and_entities(self):
+        parser = GENERATOR.PageMetadataParser()
+        parser.feed('<html lang="en"><title> Fish &amp;\n chips </title></html>')
+        self.assertEqual(parser.title, "Fish & chips")
+        self.assertEqual(parser.declared_language, "en")
+
+    def test_markdown_link_text_is_escaped(self):
+        self.assertEqual(
+            GENERATOR.markdown_link_text(r"A [draft] \\"),
+            r"A \[draft\] \\\\",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a root `llms.txt` that maps all 84 Norwegian Customs documentation pages
- group pages into stable service-guide and API-reference sections, with Norwegian/English labels
- add a dependency-free Python generator that derives titles and URLs from the tracked HTML files
- document generation and freshness-check commands
- add tests for deterministic output, complete page coverage, title parsing, and Markdown escaping

## Why

`llms.txt` is an emerging proposal for giving language models a concise, structured map of a website at inference time. This repository is a dependency-free static site, so the implementation deliberately uses only the Python standard library and commits the generated file for GitHub Pages to serve directly.

Proposal: https://llmstxt.org/

## Impact

There is no runtime behavior change for human visitors. Agents that look for `/llms.txt` receive a structured index, while maintainers can regenerate or verify it locally whenever documentation pages change.

## Validation

- independent subagent review: **Approve**, no findings
- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s tests -v` — 4/4 passed
- `python3 scripts/generate_llms_txt.py --check` — passed
- proposal structure validated: H1, summary blockquote, detail paragraph, and H2 URL lists
- all 84 HTML pages appear exactly once as unique, locally resolvable URLs
- `git diff --check` — passed
